### PR TITLE
Invert drag rotation direction

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,8 +79,8 @@
     const dx = e.clientX - startX;
     if (Math.abs(dx) < DEADZONE_PX) return;
 
-    // Negative dx => drag left => increase sector index (turn right)
-    const step = Math.trunc(-dx / PX_PER_STEP);
+    // Positive dx => drag right => increase sector index (turn right)
+    const step = Math.trunc(dx / PX_PER_STEP);
 
     if (step !== lastStep) {
       lastStep = step;


### PR DESCRIPTION
### Motivation
- The horizontal drag mapping was reversed so rightward pointer drags rotated the cylinder left; this change aligns drag direction so rightward drags rotate the cylinder right.

### Description
- Update `index.html` pointermove logic to compute `step` with `Math.trunc(dx / PX_PER_STEP)` instead of `Math.trunc(-dx / PX_PER_STEP)`, and adjust the inline comment to reflect the new direction.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697009ba143083298426bdd665616044)