### PR TITLE
Make cylinder follow pointer drag and add swipe-down soft drop

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,16 +60,21 @@
   let dragging = false;
   let startX = 0;
   let startRot = 0;
+  let startY = 0;
   let lastStep = 0;
+  let lastDropStep = 0;
 
   const PX_PER_STEP = 34;        // smaller => more sensitive (like iOS picker)
   const DEADZONE_PX = 6;
+  const PX_PER_DROP = 18;        // smaller => faster soft drop
 
   canvas.addEventListener('pointerdown', (e) => {
     dragging = true;
     startX = e.clientX;
+    startY = e.clientY;
     startRot = targetRot;  // integer sector baseline
     lastStep = 0;
+    lastDropStep = 0;
     rotVel = 0;
     canvas.setPointerCapture(e.pointerId);
   });
@@ -77,16 +82,28 @@
   canvas.addEventListener('pointermove', (e) => {
     if (!dragging) return;
     const dx = e.clientX - startX;
-    if (Math.abs(dx) < DEADZONE_PX) return;
+    const dy = e.clientY - startY;
+    if (Math.abs(dx) < DEADZONE_PX && Math.abs(dy) < DEADZONE_PX) return;
 
-    // Negative dx => drag left => increase sector index (turn right)
-    const step = Math.trunc(-dx / PX_PER_STEP);
+    if (Math.abs(dx) >= DEADZONE_PX) {
+      // Positive dx => drag right => increase sector index (turn right)
+      const step = Math.trunc(dx / PX_PER_STEP);
 
-    if (step !== lastStep) {
-      lastStep = step;
-      targetRot = startRot + step; // integer stepping
-      rotFloat = targetRot;        // immediate snap
-      rotVel = 0;
+      if (step !== lastStep) {
+        lastStep = step;
+        targetRot = startRot + step; // integer stepping
+        rotFloat = targetRot;        // immediate snap
+        rotVel = 0;
+      }
+    }
+
+    if (dy > DEADZONE_PX) {
+      const dropStep = Math.trunc(dy / PX_PER_DROP);
+      if (dropStep > lastDropStep) {
+        const steps = dropStep - lastDropStep;
+        for (let i = 0; i < steps; i++) tryMoveDown();
+        lastDropStep = dropStep;
+      }
     }
   });
 
@@ -207,7 +224,7 @@
   }
 
   function sectorCenterXY(centerX, yScreen, radiusX, radiusY, s, rot) {
-    const ang = ((s - rot) / N) * TAU + ANG_OFFSET;
+    const ang = ((s + rot) / N) * TAU + ANG_OFFSET;
     return {
       x: centerX + Math.cos(ang) * radiusX,
       y: yScreen + Math.sin(ang) * radiusY,


### PR DESCRIPTION
### Motivation
- Ensure the cylinder rotation follows the finger/mouse direction so a rightward drag rotates the cylinder right and vice versa.
- Provide a quick soft-drop mechanism by allowing downward swipes to accelerate piece falling.
- Keep horizontal and vertical drag handling independent so rotating and dropping can be done in the same drag gesture.

### Description
- Add `startY`, `lastDropStep`, and `PX_PER_DROP` and record/reset them on `pointerdown` to support vertical swipe tracking.
- Update `pointermove` to use `const step = Math.trunc(dx / PX_PER_STEP)` and only apply horizontal stepping when `Math.abs(dx) >= DEADZONE_PX` so rotation follows drag direction; keep rotation snap via `targetRot`/`rotFloat`/`rotVel` update.
- Add vertical swipe handling in `pointermove` that computes `dropStep = Math.trunc(dy / PX_PER_DROP)` and calls `tryMoveDown()` for newly crossed drop steps.
- Change sector angle calculation in `sectorCenterXY` to use `((s + rot) / N) * TAU + ANG_OFFSET` so rendered block positions match the updated rotation sign.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697009ba143083298426bdd665616044)