### PR TITLE
Fix rotation projection and finalize drag behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,16 +60,19 @@
   let dragging = false;
   let startX = 0;
   let startRot = 0;
-  let lastStep = 0;
+  let startY = 0;
+  let lastDropStep = 0;
 
   const PX_PER_STEP = 34;        // smaller => more sensitive (like iOS picker)
   const DEADZONE_PX = 6;
+  const PX_PER_DROP = 18;        // smaller => faster soft drop
 
   canvas.addEventListener('pointerdown', (e) => {
     dragging = true;
     startX = e.clientX;
-    startRot = targetRot;  // integer sector baseline
-    lastStep = 0;
+    startY = e.clientY;
+    startRot = rotFloat;   // continuous baseline
+    lastDropStep = 0;
     rotVel = 0;
     canvas.setPointerCapture(e.pointerId);
   });
@@ -77,16 +80,23 @@
   canvas.addEventListener('pointermove', (e) => {
     if (!dragging) return;
     const dx = e.clientX - startX;
-    if (Math.abs(dx) < DEADZONE_PX) return;
+    const dy = e.clientY - startY;
+    if (Math.abs(dx) < DEADZONE_PX && Math.abs(dy) < DEADZONE_PX) return;
 
-    // Negative dx => drag left => increase sector index (turn right)
-    const step = Math.trunc(-dx / PX_PER_STEP);
-
-    if (step !== lastStep) {
-      lastStep = step;
-      targetRot = startRot + step; // integer stepping
-      rotFloat = targetRot;        // immediate snap
+    if (Math.abs(dx) >= DEADZONE_PX) {
+      // Positive dx => drag right => rotate cylinder right
+      rotFloat = startRot + dx / PX_PER_STEP;
+      targetRot = rotFloat;
       rotVel = 0;
+    }
+
+    if (dy > DEADZONE_PX) {
+      const dropStep = Math.trunc(dy / PX_PER_DROP);
+      if (dropStep > lastDropStep) {
+        const steps = dropStep - lastDropStep;
+        for (let i = 0; i < steps; i++) tryMoveDown();
+        lastDropStep = dropStep;
+      }
     }
   });
 


### PR DESCRIPTION
### Motivation
- Prevent the falling piece from shifting left/right while the cylinder is rotated so horizontal drags only rotate the ring.
- Restore and support vertical swipe-to-soft-drop behavior so downward swipes step the falling piece down.
- Ensure the rendered block positions match the runtime rotation by correcting the sector angle sign.

### Description
- Adjusted sector projection math in `sectorCenterXY` to `const ang = ((s - rot) / N) * TAU + ANG_OFFSET` so the active piece remains centered while the cylinder rotates.
- Use `rotFloat` as the drag baseline by setting `startRot = rotFloat` on `pointerdown` and zeroing `rotVel` so the visual follows the pointer without inertial snapping.
- Replace integer stepping logic with continuous horizontal mapping `rotFloat = startRot + dx / PX_PER_STEP` and add vertical soft-drop support using `startY`, `lastDropStep`, `PX_PER_DROP`, and calling `tryMoveDown()` for newly crossed drop steps.
- Tighten deadzone handling to require movement in either axis before reacting so small jitter doesn’t trigger rotation or drops.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697009ba143083298426bdd665616044)